### PR TITLE
change S2ProxyTargetLocator.logger to static S2ProxyTargetLocator.LOGGER

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <!-- The Basics -->
   <groupId>org.seasar.wicket</groupId>
   <artifactId>s2wicket-parent</artifactId>
-  <version>6.16.1</version>
+  <version>6.16.2</version>
   <packaging>pom</packaging>
   <modules>
     <module>s2wicket</module>

--- a/s2wicket-example/pom.xml
+++ b/s2wicket-example/pom.xml
@@ -53,7 +53,7 @@
   <parent>
     <groupId>org.seasar.wicket</groupId>
     <artifactId>s2wicket-parent</artifactId>
-    <version>6.16.1</version>
+    <version>6.16.2</version>
   </parent>
 
   <!-- More Project Information -->

--- a/s2wicket-libs/pom.xml
+++ b/s2wicket-libs/pom.xml
@@ -53,7 +53,7 @@
   <parent>
     <groupId>org.seasar.wicket</groupId>
     <artifactId>s2wicket-parent</artifactId>
-    <version>6.16.1</version>
+    <version>6.16.2</version>
   </parent>
 
   <!-- More Project Information -->

--- a/s2wicket/pom.xml
+++ b/s2wicket/pom.xml
@@ -49,7 +49,7 @@
   <parent>
     <groupId>org.seasar.wicket</groupId>
     <artifactId>s2wicket-parent</artifactId>
-    <version>6.16.1</version>
+    <version>6.16.2</version>
   </parent>
 
   <!-- More Project Information -->

--- a/s2wicket/src/main/java/org/seasar/wicket/injection/S2ProxyTargetLocator.java
+++ b/s2wicket/src/main/java/org/seasar/wicket/injection/S2ProxyTargetLocator.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
 public class S2ProxyTargetLocator implements IProxyTargetLocator, Serializable {
     private static final long serialVersionUID = 1L;
 
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger LOGGER = LoggerFactory.getLogger(S2ProxyTargetLocator.class);
 
     private final Object key;
 

--- a/s2wicket/src/main/java/org/seasar/wicket/injection/S2ProxyTargetLocator.java
+++ b/s2wicket/src/main/java/org/seasar/wicket/injection/S2ProxyTargetLocator.java
@@ -20,8 +20,6 @@ import java.io.Serializable;
 import org.apache.wicket.proxy.IProxyTargetLocator;
 import org.seasar.framework.container.assembler.ProxyBindingTypeDef;
 import org.seasar.framework.container.factory.SingletonS2ContainerFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * S2Container用のProxyTargetLocator。

--- a/s2wicket/src/main/java/org/seasar/wicket/injection/S2ProxyTargetLocator.java
+++ b/s2wicket/src/main/java/org/seasar/wicket/injection/S2ProxyTargetLocator.java
@@ -34,8 +34,6 @@ import org.slf4j.LoggerFactory;
 public class S2ProxyTargetLocator implements IProxyTargetLocator, Serializable {
     private static final long serialVersionUID = 1L;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(S2ProxyTargetLocator.class);
-
     private final Object key;
 
     /**


### PR DESCRIPTION
instance param S2ProxyTargetLocator.logger will cause deserialization error in same case like different ClassLoad.